### PR TITLE
added BrE TTS support (received pronunciation)

### DIFF
--- a/src/qonlinetranslator.cpp
+++ b/src/qonlinetranslator.cpp
@@ -43,7 +43,7 @@ const QMap<QOnlineTranslator::Language, QString> QOnlineTranslator::s_genericLan
     {Belarusian, QStringLiteral("be")},
     {Bengali, QStringLiteral("bn")},
     {Bosnian, QStringLiteral("bs")},
-	{BritishEnglish, QStringLiteral("en")}, // As far as I know, no translation provider can translate into British English, only Google Translate TTS has British pronunciation.
+    {BritishEnglish, QStringLiteral("en")}, // As far as I know, no translation provider can translate into British English, only Google Translate TTS has British pronunciation.
     {Bulgarian, QStringLiteral("bg")},
     {Cantonese, QStringLiteral("yue")},
     {Catalan, QStringLiteral("ca")},
@@ -54,7 +54,7 @@ const QMap<QOnlineTranslator::Language, QString> QOnlineTranslator::s_genericLan
     {Czech, QStringLiteral("cs")},
     {Danish, QStringLiteral("da")},
     {Dutch, QStringLiteral("nl")},
-	{English, QStringLiteral("en")}, // English is American English with American pronunciation; sadly, due to widespread Anglophobia in the tech community, BritishEnglish is in fact Yanks' English with Received Pronunciation, and this is only supported by Google!
+    {English, QStringLiteral("en")}, // English is American English with American pronunciation; sadly, due to widespread Anglophobia in the tech community, BritishEnglish is in fact Yanks' English with Received Pronunciation, and this is only supported by Google!
     {Esperanto, QStringLiteral("eo")},
     {Estonian, QStringLiteral("et")},
     {Fijian, QStringLiteral("fj")},
@@ -501,8 +501,8 @@ QString QOnlineTranslator::languageName(Language lang)
         return tr("Bengali");
     case Bosnian:
         return tr("Bosnian");
-	case BritishEnglish:
-		return tr("English (British Pronunciation)");
+    case BritishEnglish:
+        return tr("English (British Pronunciation)");
     case Bulgarian:
         return tr("Bulgarian");
     case Catalan:

--- a/src/qonlinetranslator.cpp
+++ b/src/qonlinetranslator.cpp
@@ -502,7 +502,7 @@ QString QOnlineTranslator::languageName(Language lang)
     case Bosnian:
         return tr("Bosnian");
     case BritishEnglish:
-        return tr("English (British Pronunciation)");
+        return tr("English (British pronunciation)");
     case Bulgarian:
         return tr("Bulgarian");
     case Catalan:

--- a/src/qonlinetranslator.cpp
+++ b/src/qonlinetranslator.cpp
@@ -43,6 +43,7 @@ const QMap<QOnlineTranslator::Language, QString> QOnlineTranslator::s_genericLan
     {Belarusian, QStringLiteral("be")},
     {Bengali, QStringLiteral("bn")},
     {Bosnian, QStringLiteral("bs")},
+	{BritishEnglish, QStringLiteral("en")}, // As far as I know, no translation provider can translate into British English, only Google Translate TTS has British pronunciation.
     {Bulgarian, QStringLiteral("bg")},
     {Cantonese, QStringLiteral("yue")},
     {Catalan, QStringLiteral("ca")},
@@ -53,7 +54,7 @@ const QMap<QOnlineTranslator::Language, QString> QOnlineTranslator::s_genericLan
     {Czech, QStringLiteral("cs")},
     {Danish, QStringLiteral("da")},
     {Dutch, QStringLiteral("nl")},
-    {English, QStringLiteral("en")},
+	{English, QStringLiteral("en")}, // English is American English with American pronunciation; sadly, due to widespread Anglophobia in the tech community, BritishEnglish is in fact Yanks' English with Received Pronunciation, and this is only supported by Google!
     {Esperanto, QStringLiteral("eo")},
     {Estonian, QStringLiteral("et")},
     {Fijian, QStringLiteral("fj")},
@@ -500,6 +501,8 @@ QString QOnlineTranslator::languageName(Language lang)
         return tr("Bengali");
     case Bosnian:
         return tr("Bosnian");
+	case BritishEnglish:
+		return tr("English (British Pronunciation)");
     case Bulgarian:
         return tr("Bulgarian");
     case Catalan:

--- a/src/qonlinetranslator.h
+++ b/src/qonlinetranslator.h
@@ -60,7 +60,7 @@ public:
         Belarusian,
         Bengali,
         Bosnian,
-		BritishEnglish,
+        BritishEnglish,
         Bulgarian,
         Cantonese,
         Catalan,

--- a/src/qonlinetranslator.h
+++ b/src/qonlinetranslator.h
@@ -60,6 +60,7 @@ public:
         Belarusian,
         Bengali,
         Bosnian,
+		BritishEnglish,
         Bulgarian,
         Cantonese,
         Catalan,

--- a/src/qonlinetts.cpp
+++ b/src/qonlinetts.cpp
@@ -173,9 +173,9 @@ QString QOnlineTts::languageApiCode(QOnlineTranslator::Engine engine, QOnlineTra
     switch (engine) {
     case QOnlineTranslator::Google:
     case QOnlineTranslator::Lingva: // Lingva is a frontend to Google Translate
-		if (lang == QOnlineTranslator::BritishEnglish)
-			return QStringLiteral("en-GB"); // Google Translate won't translate into British English, but its TTS engine supports British pronunciation
-		else if (lang != QOnlineTranslator::Auto)
+        if (lang == QOnlineTranslator::BritishEnglish)
+            return QStringLiteral("en-GB"); // Google Translate won't translate into British English, but its TTS engine supports British pronunciation
+        else if (lang != QOnlineTranslator::Auto)
             return QOnlineTranslator::languageApiCode(engine, lang); // Google use the same codes for tts (except 'auto')
         break;
     case QOnlineTranslator::Yandex:

--- a/src/qonlinetts.cpp
+++ b/src/qonlinetts.cpp
@@ -173,7 +173,9 @@ QString QOnlineTts::languageApiCode(QOnlineTranslator::Engine engine, QOnlineTra
     switch (engine) {
     case QOnlineTranslator::Google:
     case QOnlineTranslator::Lingva: // Lingva is a frontend to Google Translate
-        if (lang != QOnlineTranslator::Auto)
+		if (lang == QOnlineTranslator::BritishEnglish)
+			return QStringLiteral("en-GB"); // Google Translate won't translate into British English, but its TTS engine supports British pronunciation
+		else if (lang != QOnlineTranslator::Auto)
             return QOnlineTranslator::languageApiCode(engine, lang); // Google use the same codes for tts (except 'auto')
         break;
     case QOnlineTranslator::Yandex:


### PR DESCRIPTION
close #40

Now, `QOnlineTranslator::English` is American English, and `QOnlineTranslator::BritishEnglish` is American English with Received Pronunciation, which means that it is spelt the Yanks' way yet pronounced with RP. E.g.: couleur -> color, and Google TTS engine pronounces it [ˈkʌlə]

Example:
```cpp
QMediaPlayer player;
QMediaPlaylist list;
QOnlineTts tts;
tts.generateUrls("squirrel", QOnlineTranslator::Google, QOnlineTranslator::BritishEnglish);
list.addMedia(tts.media());
player.setPlaylist(&list);
player.play(); // [ˈskwɪrəl]
```