### PR TITLE
Added regional voice support for Google

### DIFF
--- a/src/qonlinetts.cpp
+++ b/src/qonlinetts.cpp
@@ -35,23 +35,21 @@ const QMap<QOnlineTts::Voice, QString> QOnlineTts::s_voiceCodes = {
     {Alyss, QStringLiteral("alyss")},
     {Omazh, QStringLiteral("omazh")}};
 
-/// The codes are obtained from https://cloud.google.com/speech-to-text/docs/languages,
-/// I'm not sure if Google Translate TTS uses the same codes and unable to confirm most.
-const QMap<QOnlineTts::Region, QString> QOnlineTts::s_voiceRegionCodes = {
-    {BengaliBangladesh, QStringLiteral("bn-BD")},
-    {BengaliIndia, QStringLiteral("bn-IN")},
-    {ChineseMandarinChina, QStringLiteral("cmn-Hans-CN")},
-    {EnglishAustralia, QStringLiteral("en-AU")},
-    {EnglishIndia, QStringLiteral("en-IN")},
-    {EnglishUk, QStringLiteral("en-GB")},
-    {EnglishUs, QStringLiteral("en-US")},
-    {FrenchCanada, QStringLiteral("fr-CA")},
-    {FrenchFrance, QStringLiteral("fr-FR")},
-    {GermanGermany, QStringLiteral("de-DE")},
-    {PortugueseBrazil, QStringLiteral("pt-BR")},
-    {SpanishSpain, QStringLiteral("es-ES")},
-    {SpanishUs, QStringLiteral("es-US")},
-    {TamilIndia, QStringLiteral("ta-IN")}};
+const QMap<QPair<QOnlineTranslator::Language, QLocale::Country>, QString> QOnlineTts::s_regionCodes = {
+    {{QOnlineTranslator::Bengali, QLocale::Bangladesh}, QStringLiteral("bn-BD")},
+    {{QOnlineTranslator::Bengali, QLocale::India}, QStringLiteral("bn-IN")},
+    {{QOnlineTranslator::SimplifiedChinese, QLocale::China}, QStringLiteral("cmn-Hans-CN")},
+    {{QOnlineTranslator::English, QLocale::Australia}, QStringLiteral("en-AU")},
+    {{QOnlineTranslator::English, QLocale::India}, QStringLiteral("en-IN")},
+    {{QOnlineTranslator::English, QLocale::UnitedKingdom}, QStringLiteral("en-GB")},
+    {{QOnlineTranslator::English, QLocale::UnitedStates}, QStringLiteral("en-US")},
+    {{QOnlineTranslator::French, QLocale::Canada}, QStringLiteral("fr-CA")},
+    {{QOnlineTranslator::French, QLocale::France}, QStringLiteral("fr-FR")},
+    {{QOnlineTranslator::German, QLocale::Germany}, QStringLiteral("de-DE")},
+    {{QOnlineTranslator::Portuguese, QLocale::Brazil}, QStringLiteral("pt-BR")},
+    {{QOnlineTranslator::Spanish, QLocale::Spain}, QStringLiteral("es-ES")},
+    {{QOnlineTranslator::Spanish, QLocale::UnitedStates}, QStringLiteral("es-US")},
+    {{QOnlineTranslator::Tamil, QLocale::India}, QStringLiteral("ta-IN")}};
 
 QOnlineTts::QOnlineTts(QObject *parent)
     : QObject(parent)
@@ -164,9 +162,9 @@ QString QOnlineTts::voiceCode(Voice voice)
     return s_voiceCodes.value(voice);
 }
 
-QString QOnlineTts::regionCode(Region region)
+QString QOnlineTts::regionCode(QOnlineTranslator::Language language, QLocale::Country region)
 {
-    return s_voiceRegionCodes.value(region);
+    return s_regionCodes.value({language, region}, QOnlineTranslator::languageApiCode(QOnlineTranslator::Google, language));
 }
 
 QString QOnlineTts::emotionCode(Emotion emotion)
@@ -184,44 +182,106 @@ QOnlineTts::Voice QOnlineTts::voice(const QString &voiceCode)
     return s_voiceCodes.key(voiceCode, NoVoice);
 }
 
-QOnlineTts::Region QOnlineTts::region(const QString &regionCode)
+QPair<QOnlineTranslator::Language, QLocale::Country> QOnlineTts::region(const QString &regionCode)
 {
-    return s_voiceRegionCodes.key(regionCode, DefaultRegion);
+    return s_regionCodes.key(regionCode, {QOnlineTranslator::NoLanguage, QLocale::AnyCountry});
 }
 
-QString QOnlineTts::regionName(Region region)
+QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Country region)
 {
-    switch (region) {
-    case DefaultRegion:
+    switch (language) {
+    case QOnlineTranslator::Bengali:
+        switch (region) {
+        case QLocale::Bangladesh:
+            return tr("Bangla (Bangladesh)");
+        case QLocale::India:
+            return tr("Bangla (India)");
+        default:
+            return tr("Default region");
+        }
+    case QOnlineTranslator::SimplifiedChinese:
+        switch (region) {
+        case QLocale::China:
+            return tr("Chinese, Mandarin (China)");
+        default:
+            return tr("Default region");
+        }
+    case QOnlineTranslator::English:
+        switch (region) {
+        case QLocale::Australia:
+            return tr("English (Australia)");
+        case QLocale::India:
+            return tr("English (India)");
+        case QLocale::UnitedKingdom:
+            return tr("English (United Kingdom)");
+        case QLocale::UnitedStates:
+            return tr("English (United States)");
+        default:
+            return tr("Default region");
+        }
+    case QOnlineTranslator::French:
+        switch (region) {
+        case QLocale::Canada:
+            return tr("French (Canada)");
+        case QLocale::France:
+            return tr("French (France)");
+        default:
+            return tr("Default region");
+        }
+    case QOnlineTranslator::German:
+        switch (region) {
+        case QLocale::Germany:
+            return tr("German (Germany)");
+        default:
+            return tr("Default region");
+        }
+    case QOnlineTranslator::Portuguese:
+        switch (region) {
+        case QLocale::Brazil:
+            return tr("Portuguese (Brazil)");
+        default:
+            return tr("Default region");
+        }
+    case QOnlineTranslator::Spanish:
+        switch (region) {
+        case QLocale::Spain:
+            return tr("Spanish (Spain)");
+        case QLocale::UnitedStates:
+            return tr("Spanish (United States)");
+        default:
+            return tr("Default region");
+        }
+    case QOnlineTranslator::Tamil:
+        switch (region) {
+        case QLocale::India:
+            return tr("Tamil (India)");
+        default:
+            return tr("Default region");
+        }
+    default:
         return tr("Default region");
-    case BengaliBangladesh:
-        return tr("Bangla (Bangladesh)");
-    case BengaliIndia:
-        return tr("Bangla (India)");
-    case ChineseMandarinChina:
-        return tr("Chinese, Mandarin (China)");
-    case EnglishAustralia:
-        return tr("English (Australia)");
-    case EnglishIndia:
-        return tr("English (India)");
-    case EnglishUk:
-        return tr("English (United Kingdom)");
-    case EnglishUs:
-        return tr("English (United States)");
-    case FrenchCanada:
-        return tr("French (Canada)");
-    case FrenchFrance:
-        return tr("French (France)");
-    case GermanGermany:
-        return tr("German (Germany)");
-    case PortugueseBrazil:
-        return tr("Portuguese (Brazil)");
-    case SpanishSpain:
-        return tr("Spanish (Spain)");
-    case SpanishUs:
-        return tr("Spanish (United States)");
-    case TamilIndia:
-        return tr("Tamil (India)");
+    }
+}
+
+QList<QLocale::Country> QOnlineTts::validRegions(QOnlineTranslator::Language language)
+{
+    switch (language) {
+    case QOnlineTranslator::Bengali:
+        return {QLocale::Bangladesh, QLocale::India};
+    case QOnlineTranslator::SimplifiedChinese:
+        return {QLocale::China};
+    case QOnlineTranslator::English:
+        return {QLocale::Australia, QLocale::India, QLocale::UnitedKingdom, QLocale::UnitedStates};
+    case QOnlineTranslator::French:
+        return {QLocale::Canada, QLocale::France};
+    case QOnlineTranslator::German:
+        return {QLocale::Germany};
+    case QOnlineTranslator::Portuguese:
+        return {QLocale::Brazil};
+    case QOnlineTranslator::Spanish:
+        return {QLocale::Spain, QLocale::UnitedStates};
+    case QOnlineTranslator::Tamil:
+        return {QLocale::India};
     default:
         return {};
     }
@@ -240,10 +300,7 @@ QString QOnlineTts::languageApiCode(QOnlineTranslator::Engine engine, QOnlineTra
     case QOnlineTranslator::Google:
     case QOnlineTranslator::Lingva: // Lingva is a frontend to Google Translate
         if (lang != QOnlineTranslator::Auto) {
-            if (m_regionPreferences.contains(lang))
-                return regionCode(m_regionPreferences.value(lang));
-            else
-                return QOnlineTranslator::languageApiCode(engine, lang); // Google use the same codes for tts (except 'auto')
+            return regionCode(lang, m_regionPreferences.value(lang)); // Google use the same codes for tts (except 'auto')
         }
         break;
     case QOnlineTranslator::Yandex:
@@ -290,12 +347,12 @@ QString QOnlineTts::emotionApiCode(QOnlineTranslator::Engine engine, Emotion emo
     return {};
 }
 
-const QMap<QOnlineTranslator::Language, QOnlineTts::Region> &QOnlineTts::regions() const
+const QMap<QOnlineTranslator::Language, QLocale::Country> &QOnlineTts::regions() const
 {
     return m_regionPreferences;
 }
 
-void QOnlineTts::setRegions(const QMap<QOnlineTranslator::Language, Region> &newRegionPreferences)
+void QOnlineTts::setRegions(const QMap<QOnlineTranslator::Language, QLocale::Country> &newRegionPreferences)
 {
     m_regionPreferences = newRegionPreferences;
 }

--- a/src/qonlinetts.cpp
+++ b/src/qonlinetts.cpp
@@ -196,15 +196,11 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
             return tr("Bangla (Bangladesh)");
         case QLocale::India:
             return tr("Bangla (India)");
-        default:
-            return tr("Default region");
         }
     case QOnlineTranslator::SimplifiedChinese:
         switch (region) {
         case QLocale::China:
             return tr("Chinese, Mandarin (China)");
-        default:
-            return tr("Default region");
         }
     case QOnlineTranslator::English:
         switch (region) {
@@ -216,8 +212,6 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
             return tr("English (United Kingdom)");
         case QLocale::UnitedStates:
             return tr("English (United States)");
-        default:
-            return tr("Default region");
         }
     case QOnlineTranslator::French:
         switch (region) {
@@ -225,22 +219,16 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
             return tr("French (Canada)");
         case QLocale::France:
             return tr("French (France)");
-        default:
-            return tr("Default region");
         }
     case QOnlineTranslator::German:
         switch (region) {
         case QLocale::Germany:
             return tr("German (Germany)");
-        default:
-            return tr("Default region");
         }
     case QOnlineTranslator::Portuguese:
         switch (region) {
         case QLocale::Brazil:
             return tr("Portuguese (Brazil)");
-        default:
-            return tr("Default region");
         }
     case QOnlineTranslator::Spanish:
         switch (region) {
@@ -248,19 +236,15 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
             return tr("Spanish (Spain)");
         case QLocale::UnitedStates:
             return tr("Spanish (United States)");
-        default:
-            return tr("Default region");
         }
     case QOnlineTranslator::Tamil:
         switch (region) {
         case QLocale::India:
             return tr("Tamil (India)");
-        default:
-            return tr("Default region");
         }
-    default:
-        return tr("Default region");
     }
+
+    return tr("Default region");
 }
 
 QList<QLocale::Country> QOnlineTts::validRegions(QOnlineTranslator::Language language)

--- a/src/qonlinetts.cpp
+++ b/src/qonlinetts.cpp
@@ -299,9 +299,8 @@ QString QOnlineTts::languageApiCode(QOnlineTranslator::Engine engine, QOnlineTra
     switch (engine) {
     case QOnlineTranslator::Google:
     case QOnlineTranslator::Lingva: // Lingva is a frontend to Google Translate
-        if (lang != QOnlineTranslator::Auto) {
+        if (lang != QOnlineTranslator::Auto)
             return regionCode(lang, m_regionPreferences.value(lang)); // Google use the same codes for tts (except 'auto')
-        }
         break;
     case QOnlineTranslator::Yandex:
         switch (lang) {

--- a/src/qonlinetts.cpp
+++ b/src/qonlinetts.cpp
@@ -199,6 +199,7 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
         default:
             break;
         }
+        break;
     case QOnlineTranslator::SimplifiedChinese:
         switch (region) {
         case QLocale::China:
@@ -206,6 +207,7 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
         default:
             break;
         }
+        break;
     case QOnlineTranslator::English:
         switch (region) {
         case QLocale::Australia:
@@ -219,6 +221,7 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
         default:
             break;
         }
+        break;
     case QOnlineTranslator::French:
         switch (region) {
         case QLocale::Canada:
@@ -228,6 +231,7 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
         default:
             break;
         }
+        break;
     case QOnlineTranslator::German:
         switch (region) {
         case QLocale::Germany:
@@ -235,6 +239,7 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
         default:
             break;
         }
+        break;
     case QOnlineTranslator::Portuguese:
         switch (region) {
         case QLocale::Brazil:
@@ -242,6 +247,7 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
         default:
             break;
         }
+        break;
     case QOnlineTranslator::Spanish:
         switch (region) {
         case QLocale::Spain:
@@ -251,6 +257,7 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
         default:
             break;
         }
+        break;
     case QOnlineTranslator::Tamil:
         switch (region) {
         case QLocale::India:
@@ -258,6 +265,7 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
         default:
             break;
         }
+        break;
     default:
         break;
     }

--- a/src/qonlinetts.cpp
+++ b/src/qonlinetts.cpp
@@ -190,6 +190,44 @@ QOnlineTts::Region QOnlineTts::region(const QString &regionCode)
     return s_voiceRegionCodes.key(regionCode, DefaultRegion);
 }
 
+QString QOnlineTts::regionName(Region region)
+{
+    switch (region) {
+    case DefaultRegion:
+        return tr("Default region");
+    case BengaliBangladesh:
+        return tr("Bangla (Bangladesh)");
+    case BengaliIndia:
+        return tr("Bangla (India)");
+    case ChineseMandarinChina:
+        return tr("Chinese, Mandarin (China)");
+    case EnglishAustralia:
+        return tr("English (Australia)");
+    case EnglishIndia:
+        return tr("English (India)");
+    case EnglishUk:
+        return tr("English (United Kingdom)");
+    case EnglishUs:
+        return tr("English (United States)");
+    case FrenchCanada:
+        return tr("French (Canada)");
+    case FrenchFrance:
+        return tr("French (France)");
+    case GermanGermany:
+        return tr("German (Germany)");
+    case PortugueseBrazil:
+        return tr("Portuguese (Brazil)");
+    case SpanishSpain:
+        return tr("Spanish (Spain)");
+    case SpanishUs:
+        return tr("Spanish (United States)");
+    case TamilIndia:
+        return tr("Tamil (India)");
+    default:
+        return {};
+    }
+}
+
 void QOnlineTts::setError(TtsError error, const QString &errorString)
 {
     m_error = error;

--- a/src/qonlinetts.cpp
+++ b/src/qonlinetts.cpp
@@ -196,11 +196,15 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
             return tr("Bangla (Bangladesh)");
         case QLocale::India:
             return tr("Bangla (India)");
+        default:
+            break;
         }
     case QOnlineTranslator::SimplifiedChinese:
         switch (region) {
         case QLocale::China:
             return tr("Chinese, Mandarin (China)");
+        default:
+            break;
         }
     case QOnlineTranslator::English:
         switch (region) {
@@ -212,6 +216,8 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
             return tr("English (United Kingdom)");
         case QLocale::UnitedStates:
             return tr("English (United States)");
+        default:
+            break;
         }
     case QOnlineTranslator::French:
         switch (region) {
@@ -219,16 +225,22 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
             return tr("French (Canada)");
         case QLocale::France:
             return tr("French (France)");
+        default:
+            break;
         }
     case QOnlineTranslator::German:
         switch (region) {
         case QLocale::Germany:
             return tr("German (Germany)");
+        default:
+            break;
         }
     case QOnlineTranslator::Portuguese:
         switch (region) {
         case QLocale::Brazil:
             return tr("Portuguese (Brazil)");
+        default:
+            break;
         }
     case QOnlineTranslator::Spanish:
         switch (region) {
@@ -236,14 +248,19 @@ QString QOnlineTts::regionName(QOnlineTranslator::Language language, QLocale::Co
             return tr("Spanish (Spain)");
         case QLocale::UnitedStates:
             return tr("Spanish (United States)");
+        default:
+            break;
         }
     case QOnlineTranslator::Tamil:
         switch (region) {
         case QLocale::India:
             return tr("Tamil (India)");
+        default:
+            break;
         }
+    default:
+        break;
     }
-
     return tr("Default region");
 }
 

--- a/src/qonlinetts.cpp
+++ b/src/qonlinetts.cpp
@@ -38,7 +38,6 @@ const QMap<QOnlineTts::Voice, QString> QOnlineTts::s_voiceCodes = {
 /// The codes are obtained from https://cloud.google.com/speech-to-text/docs/languages,
 /// I'm not sure if Google Translate TTS uses the same codes and unable to confirm most.
 const QMap<QOnlineTts::Region, QString> QOnlineTts::s_voiceRegionCodes = {
-    {DefaultRegion, QStringLiteral("")},
     {BengaliBangladesh, QStringLiteral("bn-BD")},
     {BengaliIndia, QStringLiteral("bn-IN")},
     {ChineseMandarinChina, QStringLiteral("cmn-Hans-CN")},
@@ -242,7 +241,7 @@ QString QOnlineTts::languageApiCode(QOnlineTranslator::Engine engine, QOnlineTra
     case QOnlineTranslator::Lingva: // Lingva is a frontend to Google Translate
         if (lang != QOnlineTranslator::Auto) {
             if (m_regionPreferences.contains(lang))
-                return regionApiCode(engine, m_regionPreferences.value(lang));
+                return regionCode(m_regionPreferences.value(lang));
             else
                 return QOnlineTranslator::languageApiCode(engine, lang); // Google use the same codes for tts (except 'auto')
         }
@@ -291,22 +290,12 @@ QString QOnlineTts::emotionApiCode(QOnlineTranslator::Engine engine, Emotion emo
     return {};
 }
 
-QString QOnlineTts::regionApiCode(QOnlineTranslator::Engine engine, Region region)
-{
-    if (engine == QOnlineTranslator::Google) {
-        return regionCode(region);
-    }
-
-    setError(UnsupportedRegion, tr("Selected region %1 is not supported by %2").arg(QMetaEnum::fromType<Region>().valueToKey(region), QMetaEnum::fromType<QOnlineTranslator::Engine>().valueToKey(engine)));
-    return {};
-}
-
-const QMap<QOnlineTranslator::Language, QOnlineTts::Region> &QOnlineTts::regionPreferences() const
+const QMap<QOnlineTranslator::Language, QOnlineTts::Region> &QOnlineTts::regions() const
 {
     return m_regionPreferences;
 }
 
-void QOnlineTts::setRegionPreferences(const QMap<QOnlineTranslator::Language, Region> &newRegionPreferences)
+void QOnlineTts::setRegions(const QMap<QOnlineTranslator::Language, Region> &newRegionPreferences)
 {
     m_regionPreferences = newRegionPreferences;
 }

--- a/src/qonlinetts.h
+++ b/src/qonlinetts.h
@@ -22,6 +22,7 @@
 
 #include "qonlinetranslator.h"
 
+#include <QLocale>
 #include <QMediaContent>
 
 /**
@@ -79,30 +80,6 @@ public:
         Evil
     };
     Q_ENUM(Emotion)
-
-    /**
-     * @brief Defines regional accents to use
-     *
-     * Used only by Google.
-     */
-    enum Region {
-        DefaultRegion,
-        BengaliBangladesh,
-        BengaliIndia,
-        ChineseMandarinChina,
-        EnglishAustralia,
-        EnglishIndia,
-        EnglishUk,
-        EnglishUs,
-        FrenchCanada,
-        FrenchFrance,
-        GermanGermany,
-        PortugueseBrazil,
-        SpanishSpain,
-        SpanishUs,
-        TamilIndia,
-    };
-    Q_ENUM(Region)
 
     /**
      * @brief Indicates all possible error conditions found during the processing of the URLs generation
@@ -179,16 +156,6 @@ public:
     static QString voiceCode(Voice voice);
 
     /**
-     * @brief Code of the regional voice
-     *
-     * Used only by Google
-     *
-     * @param region region
-     * @return code for regional language
-     */
-    static QString regionCode(Region region);
-
-    /**
      * @brief Code of the emotion
      *
      * Used only by Yandex.
@@ -197,6 +164,17 @@ public:
      * @return code for emotion
      */
     static QString emotionCode(Emotion emotion);
+
+    /**
+     * @brief code of the regional language (voice only)
+     *
+     * Used only by Google
+     *
+     * @param language language
+     * @param region region
+     * @return code for language in region, or a region-neutral language code if region is not supported
+     */
+    static QString regionCode(QOnlineTranslator::Language language, QLocale::Country region);
 
     /**
      * @brief Emotion from code
@@ -226,26 +204,34 @@ public:
      * @param regionCode region code
      * @return corresponding region code
      */
-    static Region region(const QString &regionCode);
+    static QPair<QOnlineTranslator::Language, QLocale::Country> region(const QString &regionCode);
 
     /**
-     * @brief Region name
+     * @brief name of regional language from specified language and region
+     * @param language language
      * @param region region
-     * @return region name
+     * @return corresponding regional language name, or "Default region" if the specified region is not supported for the specified language
      */
-    static QString regionName(Region region);
+    static QString regionName(QOnlineTranslator::Language language, QLocale::Country region);
 
     /**
-     * @brief Voice region preferences
-     * @return voice region preferences
+     * @brief valid and supported regions for a particular language
+     * @param language language
+     * @return a list of valid Country enums
      */
-    const QMap<QOnlineTranslator::Language, Region> &regions() const;
+    static QList<QLocale::Country> validRegions(QOnlineTranslator::Language language);
 
     /**
-     * @brief Set voice region preferences
-     * @param region preferences
+     * @brief region preferences
+     * @return region preferences
      */
-    void setRegions(const QMap<QOnlineTranslator::Language, Region> &regionPreferences);
+    const QMap<QOnlineTranslator::Language, QLocale::Country> &regions() const;
+
+    /**
+     * @brief set region preferences
+     * @param newRegionPreferences new region preferences
+     */
+    void setRegions(const QMap<QOnlineTranslator::Language, QLocale::Country> &newRegionPreferences);
 
 private:
     void setError(TtsError error, const QString &errorString);
@@ -256,9 +242,9 @@ private:
 
     static const QMap<Emotion, QString> s_emotionCodes;
     static const QMap<Voice, QString> s_voiceCodes;
-    static const QMap<Region, QString> s_voiceRegionCodes;
+    static const QMap<QPair<QOnlineTranslator::Language, QLocale::Country>, QString> s_regionCodes;
 
-    QMap<QOnlineTranslator::Language, Region> m_regionPreferences;
+    QMap<QOnlineTranslator::Language, QLocale::Country> m_regionPreferences;
 
     static constexpr int s_googleTtsLimit = 200;
     static constexpr int s_yandexTtsLimit = 1400;

--- a/src/qonlinetts.h
+++ b/src/qonlinetts.h
@@ -32,10 +32,10 @@
  * QMediaPlayer *player = new QMediaPlayer(this);
  * QMediaPlaylist *playlist = new QMediaPlaylist(player);
  * QOnlineTts tts;
- * 
+ *
  * playlist->addMedia(tts.generateUrls("Hello World!", QOnlineTranslator::Google););
  * player->setPlaylist(playlist);
- * 
+ *
  * player->play(); // Plays "Hello World!"
  * @endcode
  */
@@ -81,6 +81,30 @@ public:
     Q_ENUM(Emotion)
 
     /**
+     * @brief Defines regional accents to use
+     *
+     * Used only by Google.
+     */
+    enum Region {
+        DefaultRegion,
+        BengaliBangladesh,
+        BengaliIndia,
+        ChineseMandarinChina,
+        EnglishAustralia,
+        EnglishIndia,
+        EnglishUk,
+        EnglishUs,
+        FrenchCanada,
+        FrenchFrance,
+        GermanGermany,
+        PortugueseBrazil,
+        SpanishSpain,
+        SpanishUs,
+        TamilIndia,
+    };
+    Q_ENUM(Region)
+
+    /**
      * @brief Indicates all possible error conditions found during the processing of the URLs generation
      */
     enum TtsError {
@@ -94,6 +118,8 @@ public:
         UnsupportedVoice,
         /** Unsupported emotion by specified engine */
         UnsupportedEmotion,
+        /** Unsupported region by specified engine */
+        UnsupportedRegion
     };
 
     /**
@@ -155,6 +181,16 @@ public:
     static QString voiceCode(Voice voice);
 
     /**
+     * @brief Code of the regional voice
+     *
+     * Used only by Google
+     *
+     * @param region region
+     * @return code for regional language
+     */
+    static QString regionCode(Region region);
+
+    /**
      * @brief Code of the emotion
      *
      * Used only by Yandex.
@@ -184,15 +220,41 @@ public:
      */
     static Voice voice(const QString &voiceCode);
 
+    /**
+     * @brief Voice region from code
+     *
+     * Used only by Google
+     *
+     * @param regionCode region code
+     * @return corresponding region code
+     */
+    static Region region(const QString &regionCode);
+
+    /**
+     * @brief Voice region preferences
+     * @return voice region preferences
+     */
+    const QMap<QOnlineTranslator::Language, Region> &regionPreferences() const;
+
+    /**
+     * @brief Set voice region preferences
+     * @param region preferences
+     */
+    void setRegionPreferences(const QMap<QOnlineTranslator::Language, Region> &regionPreferences);
+
 private:
     void setError(TtsError error, const QString &errorString);
 
     QString languageApiCode(QOnlineTranslator::Engine engine, QOnlineTranslator::Language lang);
     QString voiceApiCode(QOnlineTranslator::Engine engine, Voice voice);
     QString emotionApiCode(QOnlineTranslator::Engine engine, Emotion emotion);
+    QString regionApiCode(QOnlineTranslator::Engine engine, Region region);
 
     static const QMap<Emotion, QString> s_emotionCodes;
     static const QMap<Voice, QString> s_voiceCodes;
+    static const QMap<Region, QString> s_voiceRegionCodes;
+
+    QMap<QOnlineTranslator::Language, Region> m_regionPreferences;
 
     static constexpr int s_googleTtsLimit = 200;
     static constexpr int s_yandexTtsLimit = 1400;

--- a/src/qonlinetts.h
+++ b/src/qonlinetts.h
@@ -117,9 +117,7 @@ public:
         /** Unsupported voice by specified engine */
         UnsupportedVoice,
         /** Unsupported emotion by specified engine */
-        UnsupportedEmotion,
-        /** Unsupported region by specified engine */
-        UnsupportedRegion
+        UnsupportedEmotion
     };
 
     /**
@@ -230,19 +228,24 @@ public:
      */
     static Region region(const QString &regionCode);
 
+    /**
+     * @brief Region name
+     * @param region region
+     * @return region name
+     */
     static QString regionName(Region region);
 
     /**
      * @brief Voice region preferences
      * @return voice region preferences
      */
-    const QMap<QOnlineTranslator::Language, Region> &regionPreferences() const;
+    const QMap<QOnlineTranslator::Language, Region> &regions() const;
 
     /**
      * @brief Set voice region preferences
      * @param region preferences
      */
-    void setRegionPreferences(const QMap<QOnlineTranslator::Language, Region> &regionPreferences);
+    void setRegions(const QMap<QOnlineTranslator::Language, Region> &regionPreferences);
 
 private:
     void setError(TtsError error, const QString &errorString);
@@ -250,7 +253,6 @@ private:
     QString languageApiCode(QOnlineTranslator::Engine engine, QOnlineTranslator::Language lang);
     QString voiceApiCode(QOnlineTranslator::Engine engine, Voice voice);
     QString emotionApiCode(QOnlineTranslator::Engine engine, Emotion emotion);
-    QString regionApiCode(QOnlineTranslator::Engine engine, Region region);
 
     static const QMap<Emotion, QString> s_emotionCodes;
     static const QMap<Voice, QString> s_voiceCodes;

--- a/src/qonlinetts.h
+++ b/src/qonlinetts.h
@@ -230,6 +230,8 @@ public:
      */
     static Region region(const QString &regionCode);
 
+    static QString regionName(Region region);
+
     /**
      * @brief Voice region preferences
      * @return voice region preferences


### PR DESCRIPTION
close #40

Example:
```cpp
QMediaPlayer player;
QMediaPlaylist list;
QOnlineTts tts;
tts.setRegionPreferences({{QOnlineTranslator::English, QOnlineTts::EnglishUk}});
tts.generateUrls("squirrel", QOnlineTranslator::Google, QOnlineTranslator::English);
list.addMedia(tts.media());
player.setPlaylist(&list);
player.play();
```

I get the list of supported regional voices from the official Google Translate Android app. Turns out that it is not very impressive.

If Google encounters an unsupported region code, it won't return error; instead, it defaults to the region-neutral language code.

PS: It is my first major contribution to others' repo. Please have the goodness to tell me if I have botched it and if there's anything improperly done (for example, breach of coding style)!