### PR TITLE
Fix lingva.ml example

### DIFF
--- a/src/qonlinetts.cpp
+++ b/src/qonlinetts.cpp
@@ -136,7 +136,7 @@ void QOnlineTts::generateUrls(const QString &text, QOnlineTranslator::Engine eng
         // NOTE:
         // Lingva returns audio in strange format, use placeholder, until we'll figure it out
         //
-        // Example: https://lingva.ml/api/v1/audio/en/Hello%20World!
+        // Example: https://lingva.garudalinux.org/api/v1/audio/en/Hello%20World!
         // Will return json with uint bytes array, according to documentation
         // See: https://github.com/TheDavidDelta/lingva-translate#public-apis
         setError(UnsupportedEngine, tr("%1 engine does not support TTS").arg(QMetaEnum::fromType<QOnlineTranslator::Engine>().valueToKey(engine)));


### PR DESCRIPTION
Official https://lingva.ml/ instance replaced with https://lingva.garudalinux.org/ (garuda linux instance)

fix: https://github.com/crow-translate/QOnlineTranslator/issues/60