### PR TITLE
Enable new LibreTranslate langs

### DIFF
--- a/src/qonlinetranslator.cpp
+++ b/src/qonlinetranslator.cpp
@@ -1103,42 +1103,28 @@ bool QOnlineTranslator::isSupportTranslation(Engine engine, Language lang)
         switch (lang) {
         case NoLanguage:
         case Afrikaans:
-        case Albanian:
         case Amharic:
         case Armenian:
-        case Azerbaijani:
         case Bashkir:
         case Basque:
         case Belarusian:
-        case Bengali:
         case Bosnian:
-        case Bulgarian:
         case Cantonese:
-        case Catalan:
         case Cebuano:
         case Chichewa:
         case Corsican:
         case Croatian:
-        case Czech:
-        case Danish:
-        case Dutch:
-        case Esperanto:
-        case Estonian:
         case Fijian:
         case Filipino:
-        case Finnish:
         case Frisian:
         case Galician:
         case Georgian:
-        case Greek:
         case Gujarati:
         case HaitianCreole:
         case Hausa:
         case Hawaiian:
-        case Hebrew:
         case HillMari:
         case Hmong:
-        case Hungarian:
         case Icelandic:
         case Igbo:
         case Javanese:
@@ -1152,13 +1138,10 @@ bool QOnlineTranslator::isSupportTranslation(Engine engine, Language lang)
         case Kyrgyz:
         case Lao:
         case Latin:
-        case Latvian:
         case LevantineArabic:
-        case Lithuanian:
         case Luxembourgish:
         case Macedonian:
         case Malagasy:
-        case Malay:
         case Malayalam:
         case Maltese:
         case Maori:
@@ -1167,14 +1150,11 @@ bool QOnlineTranslator::isSupportTranslation(Engine engine, Language lang)
         case Mongolian:
         case Myanmar:
         case Nepali:
-        case Norwegian:
         case Oriya:
         case Papiamento:
         case Pashto:
-        case Persian:
         case Punjabi:
         case QueretaroOtomi:
-        case Romanian:
         case Samoan:
         case ScotsGaelic:
         case SerbianCyrillic:
@@ -1184,24 +1164,18 @@ bool QOnlineTranslator::isSupportTranslation(Engine engine, Language lang)
         case SimplifiedChinese:
         case Sindhi:
         case Sinhala:
-        case Slovak:
-        case Slovenian:
         case Somali:
         case Sundanese:
         case Swahili:
-        case Swedish:
-        case Tagalog:
         case Tahitian:
         case Tajik:
         case Tamil:
         case Tatar:
         case Telugu:
-        case Thai:
         case Tongan:
         case Turkmen:
         case Udmurt:
         case Uighur:
-        case Ukrainian:
         case Urdu:
         case Uzbek:
         case Welsh:


### PR DESCRIPTION
Enable translation for:
'Albanian', 'Azerbaijani', 'Bengali', 'Bulgarian', 'Catalan', 'Czech', 'Danish', 'Dutch', 'Esperanto', 'Estonian', 'Finnish', 'Greek', 'Hebrew', 'Hungarian', 'Latvian', 'Lithuanian', 'Malay', 'Norwegian', 'Persian', 'Romanian', 'Slovak', 'Slovenian', 'Swedish', 'Tagalog', 'Thai', 'Ukrainian'

As of now, Crow Translate gives the message "Selected translation language [] is not supported for LibreTranslate" and doesn't even try to translate.
You can find the list of languages supported by LibreTranslate here: https://www.argosopentech.com/argospm/index/

Closes https://github.com/crow-translate/QOnlineTranslator/issues/57