### PR TITLE
Handle Bing 400 error return empty output

### DIFF
--- a/src/qonlinetranslator.cpp
+++ b/src/qonlinetranslator.cpp
@@ -1549,7 +1549,12 @@ void QOnlineTranslator::parseBingTranslate()
     const QJsonObject responseObject = jsonResponse.array().first().toObject();
 
     if (jsonResponse.object().value(QStringLiteral("statusCode")).toInt(200) == 400) {
-        resetData(NetworkError, tr("Error: Bing return unhandled network error"));
+        const QString errorMessage = jsonResponse.object().value(QStringLiteral("errorMessage")).toString();
+
+        if (!errorMessage.isEmpty())
+            resetData(ServiceError, errorMessage);
+        else
+            resetData(ServiceError, tr("Error: Bing return unhandled network error"));
         return;
     }
 

--- a/src/qonlinetranslator.cpp
+++ b/src/qonlinetranslator.cpp
@@ -1548,6 +1548,11 @@ void QOnlineTranslator::parseBingTranslate()
     const QJsonDocument jsonResponse = QJsonDocument::fromJson(m_currentReply->readAll());
     const QJsonObject responseObject = jsonResponse.array().first().toObject();
 
+    if (jsonResponse.object().value(QStringLiteral("statusCode")).toInt(200) == 400) {
+        resetData(NetworkError, tr("Error: Bing return unhandled network error"));
+        return;
+    }
+
     if (m_sourceLang == Auto) {
         const QString langCode = responseObject.value(QStringLiteral("detectedLanguage")).toObject().value(QStringLiteral("language")).toString();
         m_sourceLang = language(Bing, langCode);

--- a/src/qonlinetranslator.cpp
+++ b/src/qonlinetranslator.cpp
@@ -1548,7 +1548,7 @@ void QOnlineTranslator::parseBingTranslate()
     const QJsonDocument jsonResponse = QJsonDocument::fromJson(m_currentReply->readAll());
     const QJsonObject responseObject = jsonResponse.array().first().toObject();
 
-    if (jsonResponse.object().value(QStringLiteral("statusCode")).toInt(200) == 400) {
+    if (!jsonResponse.object().value(QStringLiteral("statusCode")).isNull()) {
         const QString errorMessage = jsonResponse.object().value(QStringLiteral("errorMessage")).toString();
 
         if (!errorMessage.isEmpty())


### PR DESCRIPTION
Right now, Bing return empty object on 400 error. Because this happened on request parsing, we need to add error handling to `parseBingTranslate()`. But I don't know, if there is better way.